### PR TITLE
tomcat mirror change

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,10 +11,7 @@ default["wsi_tomcat"]["version_base"] = default["wsi_tomcat"]["version"] .split(
 # Tomcat mirrors. Feel free to add more mirrors as needed. Chef will try to grab from them in order until completed
 tomcat_url_fragment                   = "tomcat/tomcat-#{wsi_tomcat.version_base}/v#{wsi_tomcat.version}/bin/apache-tomcat-#{wsi_tomcat.version}.tar.gz"
 default["wsi_tomcat"]["file"]["archive"]["mirrors"] = [
-  "http://mirror.olnevhost.net/pub/apache/#{tomcat_url_fragment}",
-  "http://apache.mirrors.lucidnetworks.net/#{tomcat_url_fragment}",
-  "http://www.webhostingreviewjam.com/mirror/apache/#{tomcat_url_fragment}",
-  "http://mirror.nexcess.net/apache/#{tomcat_url_fragment}"
+  "http://archive.apache.org/dist/#{tomcat_url_fragment}"
 ]
 # Chef will verify the SHA256 checksum of the downloaded archive
 # Generate SHA256 checksum for a file:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,10 @@ default["wsi_tomcat"]["version_base"] = default["wsi_tomcat"]["version"] .split(
 # Tomcat mirrors. Feel free to add more mirrors as needed. Chef will try to grab from them in order until completed
 tomcat_url_fragment                   = "tomcat/tomcat-#{wsi_tomcat.version_base}/v#{wsi_tomcat.version}/bin/apache-tomcat-#{wsi_tomcat.version}.tar.gz"
 default["wsi_tomcat"]["file"]["archive"]["mirrors"] = [
+  "http://mirror.olnevhost.net/pub/apache/#{tomcat_url_fragment}",
+  "http://apache.mirrors.lucidnetworks.net/#{tomcat_url_fragment}",
+  "http://www.webhostingreviewjam.com/mirror/apache/#{tomcat_url_fragment}",
+  "http://mirror.nexcess.net/apache/#{tomcat_url_fragment}",
   "http://archive.apache.org/dist/#{tomcat_url_fragment}"
 ]
 # Chef will verify the SHA256 checksum of the downloaded archive


### PR DESCRIPTION
Apache only gives mirrors for latest version.  Running exclusively from the archive should be able to access both latest and previous versions.